### PR TITLE
Sender-side distribution based on partition key

### DIFF
--- a/Stateful1/MyCommunicationListener.cs
+++ b/Stateful1/MyCommunicationListener.cs
@@ -6,6 +6,9 @@ using NServiceBus;
 
 namespace Stateful1
 {
+    using System;
+    using System.Linq;
+
     public class MyCommunicationListener : ICommunicationListener
     {
         private EndpointConfiguration _endpointConfiguration;
@@ -13,14 +16,18 @@ namespace Stateful1
 
         public MyCommunicationListener(StatefulServiceContext context)
         {
+            var client = new FabricClient();
+            var servicePartitionList = client.QueryManager.GetPartitionListAsync(new Uri("fabric:/PartitionedSpike/Stateful1"), context.PartitionId).GetAwaiter().GetResult();
+            var rangePartitionInformation = servicePartitionList.Select(x => x.PartitionInformation).Cast<Int64RangePartitionInformation>().Single(p => p.Id == context.PartitionId);
+
             _endpointConfiguration = new EndpointConfiguration(endpointName: "PartionedSpike.RangedServer");
+            _endpointConfiguration.MakeInstanceUniquelyAddressable(rangePartitionInformation.HighKey.ToString());
             _endpointConfiguration.SendFailedMessagesTo("error");
             _endpointConfiguration.AuditProcessedMessagesTo("audit");
             _endpointConfiguration.UseSerialization<JsonSerializer>();
             _endpointConfiguration.EnableInstallers();
             _endpointConfiguration.UsePersistence<InMemoryPersistence>();
-            _endpointConfiguration.MakeInstanceUniquelyAddressable(context.PartitionId.ToString());
-            _endpointConfiguration.RegisterComponents(components => components.RegisterSingleton(context) );
+            _endpointConfiguration.RegisterComponents(components => components.RegisterSingleton(context));
             var transportConfig = _endpointConfiguration.UseTransport<AzureServiceBusTransport>();
             transportConfig.ConnectionString("");
             transportConfig.UseForwardingTopology();

--- a/Stateful1/Stateful1.cs
+++ b/Stateful1/Stateful1.cs
@@ -4,7 +4,6 @@ using System.Fabric;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ServiceFabric.Data.Collections;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 

--- a/Stateful2/Stateful2.cs
+++ b/Stateful2/Stateful2.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Fabric;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ServiceFabric.Data.Collections;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 

--- a/Stateless1/MyBehavior.cs
+++ b/Stateless1/MyBehavior.cs
@@ -1,47 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Fabric;
-using System.Reflection;
 using System.Runtime.Remoting.Messaging;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ServiceFabric.Services.Client;
 using NServiceBus.Pipeline;
-using NServiceBus.Routing;
 
 namespace Stateless1
 {
     public class MyBehavior : IBehavior<IOutgoingSendContext, IOutgoingSendContext>
     {
-        private readonly UnicastRoutingTable _unicastRoutingTable;
         private readonly Func<object, object> _partitionMap;
-        private readonly Dictionary<string, string> _addressMap;
-        private readonly ServicePartitionResolver servicePartitionResolver = ServicePartitionResolver.GetDefault();
 
-        public MyBehavior(UnicastRoutingTable unicastRoutingTable, Func<object, object> partitionMap , Dictionary<string, string> addressMap)
+        public MyBehavior(Func<object, object> partitionMap)
         {
-            _unicastRoutingTable = unicastRoutingTable;
             _partitionMap = partitionMap;
-            _addressMap = addressMap;
         }
 
         public Task Invoke(IOutgoingSendContext context, Func<IOutgoingSendContext, Task> next)
         {
-            //context.Message.MessageType
-            // how to get destination endpoint here, to resolve @"fabric:/PartitionedSpike/Stateful1"
-            //unicastRoutingTable
-            var type = typeof(UnicastRoutingTable);
-            var methodInfo = type.GetMethod("GetRouteFor", BindingFlags.NonPublic | BindingFlags.Instance);
-            var route = (UnicastRoute) methodInfo.Invoke(_unicastRoutingTable, new object[] { context.Message.MessageType });
+            var partitionKey = _partitionMap(context.Message.Instance);
 
-            var uri = _addressMap[route.Endpoint];
-
-            var partitionValue = _partitionMap(context.Message.Instance);
-
-            var partitionKey = partitionValue is string ? new ServicePartitionKey((string)partitionValue) : new ServicePartitionKey((int)partitionValue);
-            var partition1 = this.servicePartitionResolver.ResolveAsync(new Uri(uri), partitionKey, CancellationToken.None).GetAwaiter().GetResult();
-            
-            CallContext.LogicalSetData("selectedPartition", partition1.Info.Id.ToString());
+            CallContext.LogicalSetData("selectedPartition", partitionKey.ToString());
             return next(context);
         }
     }

--- a/Stateless1/MyDistributionStrategy.cs
+++ b/Stateless1/MyDistributionStrategy.cs
@@ -1,11 +1,12 @@
 ﻿using System.Fabric;
-using System.Linq;
 using System.Runtime.Remoting.Messaging;
 using NServiceBus;
 using NServiceBus.Routing;
 
 namespace Stateless1
 {
+    using System.Linq;
+
     public class MyDistributionStrategy : DistributionStrategy
     {
         private readonly StatelessServiceContext _context;
@@ -17,9 +18,12 @@ namespace Stateless1
 
         public override string SelectReceiver(string[] receiverAddresses)
         {
-            var value = (string)CallContext.LogicalGetData("selectedPartition");
-            ServiceEventSource.Current.ServiceMessage(_context, "Going to route a message to partition " + value);
-            return receiverAddresses.FirstOrDefault(a => a.EndsWith(value));
+            var discriminator = (string)CallContext.LogicalGetData("selectedPartition");
+            ServiceEventSource.Current.ServiceMessage(_context, "Going to route a message to partition " + discriminator);
+
+            var logicalAddress = LogicalAddress.CreateRemoteAddress(new EndpointInstance(Endpoint, discriminator));
+
+            return receiverAddresses.FirstOrDefault(a => a == logicalAddress.ToString()); //199 vs 99
         }
     }
 }

--- a/Stateless1/Program.cs
+++ b/Stateless1/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Fabric;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Stateless1

--- a/Stateless1/Stateless1.cs
+++ b/Stateless1/Stateless1.cs
@@ -4,7 +4,6 @@ using System.Fabric;
 using System.Threading;
 using System.Threading.Tasks;
 using Contract;
-using Microsoft.ServiceFabric.Services.Client;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 using NServiceBus;


### PR DESCRIPTION
### Changes

- User provided mapping instructs how partitioning is done
- To target partitions mapping has to return
  - Partition key name for `NamedPartitionStrategy`
  - Partition high key for `Int64RangePartitionStrategy`
- Senders do not need to query SF cluster
- Senders can be outside of the SF cluster
- Receivers query SF once to determine local partition name or high key to be used as endpoint`s discriminator